### PR TITLE
Improve the performance of rocket counting

### DIFF
--- a/UIShowRocketCount/Plugin.cs
+++ b/UIShowRocketCount/Plugin.cs
@@ -34,53 +34,6 @@ namespace UIShowRocketCount
             Harmony.CreateAndPatchAll(typeof(Plugin));
         }
 
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(SessionController), "Start")]
-        static void SessionController_Start()
-        {
-            rocketInventory.Clear();
-
-            // Make a reverse map for the hidden container's group id to the world unit type
-            Dictionary<string, DataConfig.WorldUnitType> rocketIds = new();
-            foreach (var ids in GameConfig.spaceGlobalMultipliersGroupIds)
-            {
-                rocketIds.Add(ids.Value, ids.Key);
-            }
-
-            // scan all constructed world objects
-            foreach (WorldObject wo in WorldObjectsHandler.GetConstructedWorldObjects())
-            {
-                Group gr = wo.GetGroup();
-                string gid = gr.GetId();
-                // if the groupid matches, get its inventory
-                if (rocketIds.TryGetValue(gid, out var wu))
-                {
-                    rocketInventory.Add(wu, InventoriesHandler.GetInventoryById(wo.GetLinkedInventoryId()));
-                }
-            }
-
-            // find the uninstantiated hidden containers and instantiate them now
-            foreach (var ids in GameConfig.spaceGlobalMultipliersGroupIds)
-            {
-                if (!rocketInventory.ContainsKey(ids.Key))
-                {
-                    Group groupViaId = GroupsHandler.GetGroupViaId(ids.Value);
-                    var wo = WorldObjectsHandler.CreateNewWorldObject(groupViaId, 0);
-                    wo.SetPositionAndRotation(GameConfig.spaceLocation, Quaternion.identity);
-                    WorldObjectsHandler.InstantiateWorldObject(wo, false);
-
-                    rocketInventory.Add(ids.Key, InventoriesHandler.GetInventoryById(wo.GetLinkedInventoryId()));
-                }
-            }
-        }
-
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(UiWindowPause), nameof(UiWindowPause.OnQuit))]
-        static void UiWindowPause_OnQuit()
-        {
-            rocketInventory.Clear();
-        }
-
         [HarmonyPrefix]
         [HarmonyPatch(typeof(WorldUnitsGenerationDisplayer), "RefreshDisplay")]
         static bool WorldUnitsGenerationDisplayer_RefreshDisplay(ref IEnumerator __result, float timeRepeat,
@@ -176,6 +129,53 @@ namespace UIShowRocketCount
                     }
                 }
             }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(SessionController), "Start")]
+        static void SessionController_Start()
+        {
+            rocketInventory.Clear();
+
+            // Make a reverse map for the hidden container's group id to the world unit type
+            Dictionary<string, DataConfig.WorldUnitType> rocketIds = new();
+            foreach (var ids in GameConfig.spaceGlobalMultipliersGroupIds)
+            {
+                rocketIds.Add(ids.Value, ids.Key);
+            }
+
+            // scan all constructed world objects
+            foreach (WorldObject wo in WorldObjectsHandler.GetConstructedWorldObjects())
+            {
+                Group gr = wo.GetGroup();
+                string gid = gr.GetId();
+                // if the groupid matches, get its inventory
+                if (rocketIds.TryGetValue(gid, out var wu))
+                {
+                    rocketInventory.Add(wu, InventoriesHandler.GetInventoryById(wo.GetLinkedInventoryId()));
+                }
+            }
+
+            // find the uninstantiated hidden containers and instantiate them now
+            foreach (var ids in GameConfig.spaceGlobalMultipliersGroupIds)
+            {
+                if (!rocketInventory.ContainsKey(ids.Key))
+                {
+                    Group groupViaId = GroupsHandler.GetGroupViaId(ids.Value);
+                    var wo = WorldObjectsHandler.CreateNewWorldObject(groupViaId, 0);
+                    wo.SetPositionAndRotation(GameConfig.spaceLocation, Quaternion.identity);
+                    WorldObjectsHandler.InstantiateWorldObject(wo, false);
+
+                    rocketInventory.Add(ids.Key, InventoriesHandler.GetInventoryById(wo.GetLinkedInventoryId()));
+                }
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UiWindowPause), nameof(UiWindowPause.OnQuit))]
+        static void UiWindowPause_OnQuit()
+        {
+            rocketInventory.Clear();
         }
     }
 }

--- a/UIShowRocketCount/UIShowRocketCount.csproj
+++ b/UIShowRocketCount/UIShowRocketCount.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net462</TargetFramework>
     <AssemblyName>UIShowRocketCount</AssemblyName>
     <Description>(UI) Show Rocket Counts</Description>
-    <Version>1.0.0.2</Version>
+    <Version>1.0.0.3</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Platforms>AnyCPU</Platforms>


### PR DESCRIPTION
Instead of #7 

For the TI details screen, we can find the hidden rocket containers and get the rocket counts O(1).

For the rocket crafting screen, we still need to scan all objects because the GPS satellites do not seem to have a hidden container. The performance is not that critical there because we do this once per opening the screen.

Credit goes to @WildCard65 for finding the hidden rocket inventories.