### PR TITLE
Extended "No Snapping" feature to rooms and extended original functionality

### DIFF
--- a/LathreyDisableBuildConstraints/Plugin.cs
+++ b/LathreyDisableBuildConstraints/Plugin.cs
@@ -41,14 +41,16 @@ namespace LathreyDisableBuildConstraints
 
         }
 
-        [HarmonyPostfix]
+        [HarmonyPrefix]
         [HarmonyPatch(typeof(BuildConstraint), "GetIsRespected")]
-        private static void BuildConstraint_GetIsRespected_Postfix(ref bool __result)
+        private static bool BuildConstraint_GetIsRespected_Prefix(ref bool __result)
         {
             if (constraintsDisabled)
             {
                 __result = true;
+                return false;
             }
+            return true;
         }
 
         [HarmonyPrefix]
@@ -56,8 +58,25 @@ namespace LathreyDisableBuildConstraints
 
         private static bool SnapPoint_OnTriggerEnter_Prefix()
         {
-            if (snappingDisabled)
+            return !snappingDisabled;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ConstraintAgainstPanel), "LateUpdate")]
+
+        private static bool ConstraintAgainstPanel_LateUpdate_Prefix()
+        {
+            return !snappingDisabled;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ActionDeconstructible), "CheckSomethingInsideIfNeeded")]
+
+        private static bool ActionDeconstructible_CheckSomethingInsideIfNeeded_Prefix(ref bool __result)
+        {
+            if (constraintsDisabled)
             {
+                __result = true;
                 return false;
             }
             return true;


### PR DESCRIPTION
Previous iteration worked only on objects like stairs and foundations. Now should affect rooms too.

Modified original "No Build Constraints" feature:
* changed original code from postfix to prefix;
* add override for ActionDeconstructible.CheckSomethingInsideIfNeeded to allow deconstructing rooms with objects (only room is deconstructed).

First since there's no need to call original check when result is discarded. It still called when feature is disabled.

Second because it let you build intersecting rooms and depending on the object which end up inside and placement of the rooms it might become indestructible.

Note: If you enable "No Snapping" while building a new room and snapping icon is on screen it will remain on screen until you build it, cancel building or disable "No Snapping" and point away. I may fix this later. Also, it seems like passages between rooms generated on proximity, so you can build two rooms at a short distance away from each other and even not on the same level and yet there'll be a passage between them despite a gap.