### PR TITLE
Stacking: Fix drone not releasing + fix slow atTargetQueue processing

### DIFF
--- a/CheatInventoryStacking/CheatInventoryStacking.csproj
+++ b/CheatInventoryStacking/CheatInventoryStacking.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName></AssemblyName>
     <Description>(Cheat) Inventory Stacking</Description>
-    <Version>1.0.2.11</Version>
+    <Version>1.0.2.12</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Platforms>AnyCPU</Platforms>

--- a/CheatInventoryStacking/Plugin_LogisticManager.cs
+++ b/CheatInventoryStacking/Plugin_LogisticManager.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Unity.Collections;
+using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.Jobs;
 
@@ -445,8 +447,9 @@ namespace CheatInventoryStacking
                             {
                                 var go = dist.GetMachineDroneStation().TryToReleaseOneDrone();
                                 // Log("      LogisticManager::SetLogisticTasks drone found: " + (go != null));
-                                if (go != null && go.TryGetComponent<Drone>(out var drone))
+                                if (go != null)
                                 {
+                                    Drone drone = go.GetComponentInChildren<Drone>();
                                     drone.AddDroneToFleet();
                                     drone.SetLogisticTask(task, ____allDroneStations);
                                     break;
@@ -691,6 +694,37 @@ namespace CheatInventoryStacking
                 }
             }
             return true;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(LogisticManager), "RemoveDroneFromFleet")]
+        static bool Patch_LogisticManager_RemoveDroneFromFleet(
+            LogisticManager __instance,
+            Drone drone,
+            ref int ____accessArrayIndexAvailable,
+            ref NativeQueue<int> ____accessAtTargetQueue,
+            ref TransformAccessArray ____accessArray,
+            List<Drone> ____accessArrayCorrespondingDrones,
+            HashSet<Drone> ____droneFleet
+        )
+        {
+            if (__instance.IsServer && drone.AccessArrayIndex >= 0)
+            {
+                mLogisticManagerCompleteDroneTransformUpdateJob.Invoke(__instance, []);
+
+                int _accessAtTargetQueue_ElementCount = ____accessAtTargetQueue.Count;
+                for (int i = 0; i < _accessAtTargetQueue_ElementCount; i++)
+                {
+                    int droneAccessIndex = ____accessAtTargetQueue.Dequeue();
+                    if (droneAccessIndex != drone.AccessArrayIndex) ____accessAtTargetQueue.Enqueue(droneAccessIndex);
+                }
+
+                ____accessArrayIndexAvailable = math.min(____accessArrayIndexAvailable, drone.AccessArrayIndex);
+                ____accessArray[drone.AccessArrayIndex] = null;
+                ____accessArrayCorrespondingDrones[drone.AccessArrayIndex] = null;
+            }
+            ____droneFleet.Remove(drone);
+            return false;
         }
 
         [HarmonyPrefix]

--- a/solution_private.targets
+++ b/solution_private.targets
@@ -78,6 +78,16 @@
 			<HintPath>$(GameManaged)\com.rlabrecque.steamworks.net.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="Collections">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>$(GameManaged)\Unity.Collections.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="Unity.Mathematics">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>$(GameManaged)\Unity.Mathematics.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 	</ItemGroup>
 
 	<!--

--- a/version_info.txt
+++ b/version_info.txt
@@ -15,7 +15,7 @@ akarnokd.theplanetcraftermods.cheatautostore=1.0.0.21
 # (Cheat) Craft From Nearby Containers
 akarnokd.theplanetcraftermods.cheatcraftfromnearbycontainers=1.0.0.79
 # (Cheat) Inventory Stacking
-akarnokd.theplanetcraftermods.cheatinventorystacking=1.0.2.11
+akarnokd.theplanetcraftermods.cheatinventorystacking=1.0.2.12
 # (Cheat) Machines Deposit Into Remote Containers
 akarnokd.theplanetcraftermods.cheatmachineremotedeposit=1.0.0.47
 # (Cheat) Minimap


### PR DESCRIPTION
Released drones didn't start their task, because Drones have a Network GameObject parent and the Drone script is in a child GameObject, which means go.TryGetComponent<Drone>(out var drone) didn't find the Drone component and didn't start the task.

LogisticManager.Update processes tasks that reached their target, but stop when the reached target is a drone station. Therefore, only one drone can enter a station in one frame and all other atTarget tasks are dismissed in the current frame, which delays the execution of those tasks. If more than one drone reaches a drone station per frame, this queue will grow until the drone logistics grinds to a halt.
The new patch takes over the vanilla routine and, instead of clearing the atTarget queue, only removes the drone index that needs to be removed.