### PR TITLE
Fix /tpp stuck in loading screen

### DIFF
--- a/FeatCommandConsole/Plugin.cs
+++ b/FeatCommandConsole/Plugin.cs
@@ -1114,7 +1114,23 @@ namespace FeatCommandConsole
                     {
                         if (ap.id.Equals(args[1], StringComparison.InvariantCultureIgnoreCase))
                         {
-                            PlanetNetworkLoader.Instance.SwitchToPlanet(ap);
+							NetworkBackendProvider.GetActiveBackend().SetSessionJoinabilityAsync(SessionJoinabilityStatus.PlanetSwitch);
+
+							Action planetLoadedReplacement = null;
+							planetLoadedReplacement = new Action(delegate () {
+								Managers.GetManager<MeshOccluderHandler>().SpeedUpProcess(5);
+
+								CanvasLoading.Instance.Toggle(false);
+								NetworkBackendProvider.GetActiveBackend().SetSessionJoinabilityAsync(SessionJoinabilityStatus.Joinable);
+
+								PlanetLoader manager = Managers.GetManager<PlanetLoader>();
+								manager.planetIsLoaded = (Action)Delegate.Remove(manager.planetIsLoaded, new Action(planetLoadedReplacement));
+							});
+
+							PlanetLoader planetLoader = Managers.GetManager<PlanetLoader>();
+							planetLoader.planetIsLoaded = (Action)Delegate.Combine(planetLoader.planetIsLoaded, planetLoadedReplacement);
+
+							PlanetNetworkLoader.Instance.SwitchToPlanet(ap);
                             found = true;
                             break;
                         }


### PR DESCRIPTION
Bug: /TPP gets stuck in the new loading screen.

v2.006 added SpaceCraft.CanvasLoading, which adds a loading screen. 

The loading screen needs to be disabled, because /TPP calls `PlanetNetworkLoader.SwitchToPlanet` -> `PNL.SwitchToPlanetServerRpc` -> `PNL.SwitchToPlanetClientRpc` -> `PlanetLoader.LoadPlanet` -> `PlanetLoader.LoadScene` calls `CanvasLoading.Instance.Toggle(true);`, which enables the loading screen inside vanilla code.

For the planet switch of the travel rocket, `MachineDeparturePlatform.PlanetLoaded` is registered to `PlanetLoader.planetIsLoaded` and that action includes the disabling of the loading screen. /TPP didn't register `MDP.PlanetLoaded`, so the loading screen can never be disabled by the vanilla game.

This commit adds an action to end the loading screen and it sets the recently added joinability states.